### PR TITLE
Add jquery validation bundle

### DIFF
--- a/VehicleRouting/App_Start/BundleConfig.cs
+++ b/VehicleRouting/App_Start/BundleConfig.cs
@@ -14,6 +14,9 @@ namespace VehicleRouting
             bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
                 "~/Scripts/jquery-{version}.js"));
 
+            bundles.Add(new ScriptBundle("~/bundles/jqueryval").Include(
+                "~/Scripts/jquery.validate*"));
+
             // Use the development version of Modernizr to develop with and learn from. Then, when you're
             // ready for production, use the build tool at http://modernizr.com to pick only the tests you need.
             bundles.Add(new ScriptBundle("~/bundles/modernizr").Include(


### PR DESCRIPTION
This bundle is required when creating views via MVC EF controller creation. We are not using it yet but it was 404ing the server output.